### PR TITLE
Use the public name of the virtual library in implementation field

### DIFF
--- a/src/ctypes-foreign-threaded/dune
+++ b/src/ctypes-foreign-threaded/dune
@@ -5,5 +5,5 @@
   (pps bisect_ppx -conditional))
  (libraries ctypes threads)
  (private_modules Ctypes_foreign_threaded_stubs)
- (implements ctypes_foreign)
+ (implements ctypes-foreign)
  (c_names foreign_threaded_stubs))


### PR DESCRIPTION
This seems to fix an issue we have in RWO and according to the dune team it should work with both the public and private name anyway!