### PR TITLE
Install ocaml_integers.h

### DIFF
--- a/src/ctypes/dune
+++ b/src/ctypes/dune
@@ -3,6 +3,11 @@
   ctypes_primitives.ml
   (run ../configure/gen_c_primitives.exe)))
 
+(rule
+ (deps (:header %{lib:integers:ocaml_integers.h}))
+ (target ocaml_integers.h)
+ (action (copy %{header} %{target})))
+
 (library
  (name ctypes)
  (public_name ctypes)
@@ -14,7 +19,8 @@
  (install_c_headers ctypes_raw_pointer ctypes_primitives
    ctypes_cstubs_internals ctypes_managed_buffer_stubs
    ctypes_complex_compatibility cstubs_internals ctypes_ldouble_stubs
-   ctypes_complex_stubs ctypes_type_info_stubs)
+   ctypes_complex_stubs ctypes_type_info_stubs
+   ocaml_integers)
  (foreign_stubs
   (language c)
   (names complex_stubs ctypes_bigarrays ctypes_roots ldouble_stubs


### PR DESCRIPTION
#### Problem

I encountered the following while trying to cross-compile the `luv` package (my own setup / not opam-monorepo / but using your Dune-ified ocaml-ctypes package):

```
jonah@DK-MCHO-Mac-M1-A luv % dune build -x darwin_x86_64 @install
        bash src/c/generate_types_step_2.exe (exit 1)
(cd _build/default/src/c && /bin/bash config/compile_c.sh generate_types_step_2.c /private/tmp/dckbuild/darwin_x86_64/Debug/dksdk/_opam/lib/ctypes generate_types_step_2.exe clang -arch arm64 -O2 -fno-strict-aliasing -fwrapv -arch arm64)
In file included from generate_types_step_2.c:8:
In file included from /private/tmp/dckbuild/darwin_x86_64/Debug/dksdk/_opam/lib/ctypes/ctypes_cstubs_internals.h:13:
/private/tmp/dckbuild/darwin_x86_64/Debug/dksdk/_opam/lib/ctypes/ctypes_primitives.h:16:10: fatal error: 'ocaml_integers.h' file not found
```

#### Solution

The Makefile-based version simply copies that `ocaml_integers.h` file from the `integers` package. This PR does the equivalent in Dune.

Confer: https://github.com/ocamllabs/ocaml-ctypes/blob/9048ac78b885cc3debeeb020c56ea91f459a4d33/Makefile#L87

Note: If this is the wrong upstream for Dune-ified ocaml-ctypes, please tell me where to submit the PR. I located it from https://github.com/dune-universe/opam-overlays/blob/master/packages/ctypes/ctypes.0.17.1%2Bdune/opam